### PR TITLE
Fix ParseUndecodedKeys return value bug

### DIFF
--- a/builder/config_reader.go
+++ b/builder/config_reader.go
@@ -124,16 +124,10 @@ func parseConfig(reader io.Reader, relativeToDir, path string) (Config, error) {
 
 	undecodedKeys := tomlMetadata.Undecoded()
 	if len(undecodedKeys) > 0 {
-		errorKeys := config.ParseUndecodedKeys(undecodedKeys)
+		unknownElementsMsg := config.FormatUndecodedKeys(undecodedKeys)
 
-		pluralizedElement := "element"
-		if len(errorKeys) > 1 {
-			pluralizedElement += "s"
-		}
-
-		return Config{}, errors.Errorf("unknown configuration %s %s in %s",
-			pluralizedElement,
-			errorKeys,
+		return Config{}, errors.Errorf("%s in %s",
+			unknownElementsMsg,
 			style.Symbol(path),
 		)
 	}

--- a/builder/config_reader_test.go
+++ b/builder/config_reader_test.go
@@ -108,30 +108,31 @@ func testConfig(t *testing.T, when spec.G, it spec.S) {
 				})
 			})
 
-			when("'uri' is misspelled as url", func() {
+			when("unknown buildpack key is present", func() {
 				it.Before(func() {
 					h.AssertNil(t, ioutil.WriteFile(builderConfigPath, []byte(`
-[buildpack]
+[[buildpacks]]
 url = "noop-buildpack.tgz"
 `), 0666))
 				})
 
-				it("returns errors when 'uri' is misspelled as 'url'", func() {
+				it("returns an error", func() {
 					_, _, err := builder.ReadConfig(builderConfigPath)
-					h.AssertError(t, err, "unknown configuration elements 'buildpack'")
+					h.AssertError(t, err, "unknown configuration element 'buildpacks.url'")
 				})
 			})
-			when("'buildpack' is misspelled", func() {
+
+			when("unknown array table is present", func() {
 				it.Before(func() {
 					h.AssertNil(t, ioutil.WriteFile(builderConfigPath, []byte(`
-[buidlpack]
+[[buidlpack]]
 uri = "noop-buildpack.tgz"
 `), 0666))
 				})
 
-				it("returns errors when 'buildpack' is misspelled as 'buidlpack'", func() {
+				it("returns an error", func() {
 					_, _, err := builder.ReadConfig(builderConfigPath)
-					h.AssertError(t, err, "unknown configuration elements 'buidlpack'")
+					h.AssertError(t, err, "unknown configuration element 'buidlpack'")
 				})
 			})
 		})

--- a/buildpackage/config_reader.go
+++ b/buildpackage/config_reader.go
@@ -39,16 +39,10 @@ func (r *ConfigReader) Read(path string) (Config, error) {
 
 	undecodedKeys := tomlMetadata.Undecoded()
 	if len(undecodedKeys) > 0 {
-		errorKeys := config.ParseUndecodedKeys(undecodedKeys)
+		unknownElementsMsg := config.FormatUndecodedKeys(undecodedKeys)
 
-		pluralizedElement := "element"
-		if len(errorKeys) > 1 {
-			pluralizedElement += "s"
-		}
-
-		return packageConfig, errors.Errorf("unknown configuration %s %s in %s",
-			pluralizedElement,
-			errorKeys,
+		return packageConfig, errors.Errorf("%s in %s",
+			unknownElementsMsg,
 			style.Symbol(path),
 		)
 	}

--- a/buildpackage/config_reader_test.go
+++ b/buildpackage/config_reader_test.go
@@ -140,7 +140,7 @@ func testBuildpackageConfigReader(t *testing.T, when spec.G, it spec.S) {
 
 			_, err = packageConfigReader.Read(configFile)
 			h.AssertNotNil(t, err)
-			h.AssertError(t, err, "unknown configuration element")
+			h.AssertError(t, err, "unknown configuration element ")
 			h.AssertError(t, err, "buildpack.url")
 			h.AssertError(t, err, configFile)
 		})

--- a/internal/config/config_helpers.go
+++ b/internal/config/config_helpers.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/BurntSushi/toml"
@@ -8,7 +9,7 @@ import (
 	"github.com/buildpacks/pack/internal/style"
 )
 
-func ParseUndecodedKeys(undecodedKeys []toml.Key) string {
+func FormatUndecodedKeys(undecodedKeys []toml.Key) string {
 	unusedKeys := map[string]interface{}{}
 	for _, key := range undecodedKeys {
 		keyName := key.String()
@@ -24,5 +25,12 @@ func ParseUndecodedKeys(undecodedKeys []toml.Key) string {
 	for errorKey := range unusedKeys {
 		errorKeys = append(errorKeys, style.Symbol(errorKey))
 	}
-	return strings.Join(errorKeys, ", ")
+
+	pluralizedElement := "element"
+	if len(errorKeys) > 1 {
+		pluralizedElement += "s"
+	}
+	elements := strings.Join(errorKeys, ", ")
+
+	return fmt.Sprintf("unknown configuration %s %s", pluralizedElement, elements)
 }


### PR DESCRIPTION
Also provide valid table when we are testing invalid key, so that
the test expectation is correct.

Signed-off-by: Natalie Arellano <narellano@vmware.com>